### PR TITLE
Changing how to format script/function param blocks.

### DIFF
--- a/PowerShell/CHANGELOG.md
+++ b/PowerShell/CHANGELOG.md
@@ -1,0 +1,25 @@
+
+# 2.0.0
+
+* Formatting (all lines include breaks at 120 characters).
+* Added section on strings: when to use single quotes, how to embed interpolated expressions, when its OK to not quote
+  some strings.
+* Updated function/script parameter standard:
+  * Comments should now go before the `[Parameter()]` attribute instead of after.
+  * There should be a space between the parameter's type and name.
+* Added paragraph on how to break strings longer than 120 characters across multiple lines.
+
+
+# 1.1.0
+
+* Added standards on casing of variable and parameter names.
+* Increased maximum line length from 100 characters to 120 characters.
+
+
+# 1.0.1
+
+* Created [Get-LowerCaseTypeAccelerator.ps1](Get-LowerCaseTypeAccelerator.ps1) script for getting the list of type
+  accelerators.
+* [Edit-PSFileContentTypeCase.ps1](Edit-PSFileContentTypeCase.ps1): Fixed regular expression for finding and changing
+  type case.
+* Fixed a typo.

--- a/PowerShell/README.md
+++ b/PowerShell/README.md
@@ -1,7 +1,12 @@
 
 # PowerShell Coding and Style Guide
 
-This document explains our PowerShell coding standards and guidelines. Following these will keep our code consistent and easier to understand and maintain.
+Version 2.0.0 (2021-10-14)
+
+[CHANGELOG](CHANGELOG.md)
+
+This document explains our PowerShell coding standards and guidelines. Following these will keep our code consistent and
+easier to understand and maintain.
 
 # Variables
 
@@ -15,32 +20,64 @@ info.)
 
 When declaring explicit variable or parameter types, always use the case of the type. 
 
-PowerShell has special type accelerators that are aliases to special types. It should be clear in your code that you're using a type accelerator, so they should always be lower case if the accelerator is an alias to a type with a different name (e.g. `[int]` for `Int32`) or not in the `System` namespace (e.g. `[ipaddress]` for `System.Net.IPAddress`). 
+PowerShell has special type accelerators that are aliases to special types. It should be clear in your code that you're
+using a type accelerator, so they should always be lower case if the accelerator is an alias to a type with a different
+name (e.g. `[int]` for `Int32`) or not in the `System` namespace (e.g. `[ipaddress]` for `System.Net.IPAddress`). 
 
 Never use the `System`  part of a class's name. PowerShell adds it for you automatically.
 
 ```powershell
-[String]$var1 = 'var1'
-[ipaddress]$ip = [ipaddress]'10.1.1.2'
-[int]$numTries = 10
-[Object]$InputObject
-[hashtable]$Parameter
-[switch]$Clean
+[String] $var1 = 'var1'
+[ipaddress] $ip = [ipaddress]'10.1.1.2'
+[int] $numTries = 10
+[Object] $InputObject
+[hashtable] $Parameter
+[switch] $Clean
 [pscustomobject]@{ 'Name' = $name }
 $ErrorActionPreference = [Management.Automation.ActionPreference]::Stop
 ```
 
-Use the [Get-LowerCaseTypeAccelerator.ps1](Get-LowerCaseTypeAccelerator.ps1) script to get the list of all type names that should be lower case.
+Use the [Get-LowerCaseTypeAccelerator.ps1](Get-LowerCaseTypeAccelerator.ps1) script to get the list of all type names
+that should be lower case.
 
-The [Edit-PSFileContentTypeCase.ps1](Edit-PSFileContentTypeCase.ps1) script will update your scripts to use this convention.
+The [Edit-PSFileContentTypeCase.ps1](Edit-PSFileContentTypeCase.ps1) script will update your scripts to use this
+convention.
+
+# Strings
+
+Always use single quotes around strings unless using string interpolation to embed expressions in the string. When using
+string interpolation, surround all expressions, even just variables, with `$()`.
+
+```powershell
+# If there's no interpolation in a string, always use single quotes.
+'Just a raw string.'
+
+# If using interpolation, always surround expressions and variables with `$()`.
+"Path: $($env:Path)"
+```
+
+PowerShell allows un-quoted strings as parameter values. Always quote string parameters. If the parameter is an
+enumeration (i.e. only a specific set of values are accepted), don't quote those values.
+
+```powershell
+# Always quote strings passed as parameters.
+Get-ChildItem | Where-Object 'BaseName' -Like '.*'
+
+# So that it is clear when you're passing an enum value.
+Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+```
 
 # Scripts and Functions
 
 Follow these guidelines whenever you write a standalone script.
 
-Always support `-WhatIf` if your script/function changes something
+Always support `-WhatIf` if your script/function changes something.
 
-You should use a standard PowerShell verb as the first part of a script name (see below for the exceptions). Use a dash to separate the verb from the noun/target in the second part of the name, e.g. `Initialize-DeveloperComputer.ps1`, `Repair-HgCaseFoldingCollision.ps1`, `Invoke-Robocopy.ps1`. There should only be one dash in the command's name. For help in choosing or finding a verb, see [Approved Verbs for Windows PowerShell Commands](https://docs.microsoft.com/en-us/powershell/developer/cmdlet/approved-verbs-for-windows-powershell-commands).
+You should use a standard PowerShell verb as the first part of a script name (see below for the exceptions). Use a dash
+to separate the verb from the noun/target in the second part of the name, e.g. `Initialize-DeveloperComputer.ps1`,
+`Repair-HgCaseFoldingCollision.ps1`, `Invoke-Robocopy.ps1`. There should only be one dash in the command's name. For
+help in choosing or finding a verb, see
+[Approved Verbs for Windows PowerShell Commands](https://docs.microsoft.com/en-us/powershell/developer/cmdlet/approved-verbs-for-windows-powershell-commands).
 
 Exceptions to using a standard PowerShell verb in your script's name:
 
@@ -48,9 +85,15 @@ Exceptions to using a standard PowerShell verb in your script's name:
 * `build.ps1`: for the script that builds the code in your repository
 * `install.ps1`: for the script that installs the software on the local computer.
 
-Always include a synopsis, description, and at least one example in the documentation of your script. PowerShell has a great built-in help system. Use it! See [June Blender's "PowerShell Help Deep-Dive" talk](https://youtu.be/U7c04Vwqqgk) on how to write good documentation.
+Always include a synopsis, description, and at least one example in the documentation of your script. PowerShell has a
+great built-in help system. Use it! See [June Blender's "PowerShell Help Deep-Dive" talk](https://youtu.be/U7c04Vwqqgk)
+on how to write good documentation.
 
-Never hard-code absolute paths. If you need to reach out to an external resource, the best approach is to use a parameter to havee the user pass you the location of that resource. If that won't work, don't hard-code absolute paths. Use paths relative to your script. PowerShell 3+ has a pre-defined variable, `$PSScriptRoot`, which is the directory where your script is located. Use the `Join-Path` cmdlet to make absolute paths from the script's current location or the user's current location.
+Never hard-code absolute paths. If you need to reach out to an external resource, the best approach is to use a
+parameter to have the user pass you the location of that resource. If that won't work, don't hard-code absolute paths.
+Use paths relative to your script. PowerShell 3+ has a pre-defined variable, `$PSScriptRoot`, which is the directory
+where your script is located. Use the `Join-Path` cmdlet to make absolute paths from the script's current location or
+the user's current location.
 
 PowerShell keywords should always be in lowercase, e.g. `function`, `process`, etc.
 
@@ -69,13 +112,11 @@ command's positional parameters. Always use the parameter/switch name, e.g. `Joi
 'build.ps1'` not `Join-Path $PSScriptRoot 'build.ps1'`. This improves readability and improves forward compatibility if
 a command's positional parameters change.
 
-Always enclose strings with single quotes. Never leave strings without quotes. This makes strings easier to see in code
-editors and makes it easier to distinguish strings from constants and enumeration values.
-
 ## Parameters
 
-For script/function parameters, attributes should be ordered this way: the `Parameter` attribute, any validation
-attributes, documentation, and the parameter type (optional) and name on the same line.
+For script/function parameters, attributes should be ordered this way: documentation, the `Parameter` attribute, any
+validation attributes, documentation, and the parameter type (optional) and name on the same line. Put a space between
+the parameter's type and the name.
 
 Parameter names should be capitalized and Pascal-cased (i.e. every word begins with a capital letter. Abbreviations of
 two letters should be in all caps, e.g. ID  instead of Id .) (See the [Types](#types) section above for how to case type
@@ -84,26 +125,30 @@ names.)
 ```powershell
 [CmdletBinding(DefaultParameterSetName='FullPipeline')]
 param(
-    [Parameter(Mandatory)]
     # The settings to use.
-    [String]$Environment,
+    [Parameter(Mandatory)]
+    [String] $Environment,
     
-    [Parameter(ParameterSetName='PartialPipeline')]
     # Just build.
-    [switch]$Build,
-    
     [Parameter(ParameterSetName='PartialPipeline')]
+    [switch] $Build,
+    
     # Just migrate the database(s).
-    [switch]$MigrateDB,
+    [Parameter(ParameterSetName='PartialPipeline')]
+    [switch] $MigrateDB,
  
     # This is an optional parameter. Note the missing [Parameter()] attribute.
-    [String]$Optional
+    [String] $Optional
 )
 ```
 
-Parameter attribute property values should only be visible and set if its value is being set to a non-default value, i.e. `[Parameter(ParameterSetName='PartialPipeline')]` not `[Parameter(Mandatory=$false,ParameterSetName='PartialPipeline')]`. Boolean attribute property values must be omitted, e.g. `[Parameter(Mandatory)]`, not `[Parameter(Mandatory=$true)]`.
+Parameter attribute property values should only be visible and set if its value is being set to a non-default value,
+i.e. `[Parameter(ParameterSetName='PartialPipeline')]` not 
+`[Parameter(Mandatory=$false,ParameterSetName='PartialPipeline')]`. Boolean attribute property values must be omitted,
+e.g. `[Parameter(Mandatory)]`, not `[Parameter(Mandatory=$true)]`.
 
-Omit the parameter attribute entirely if it doesn't set any property values, e.g. omit any parameter attribute that looks like `[Parameter()]`.
+Omit the parameter attribute entirely if it doesn't set any property values, e.g. omit any parameter attribute that
+looks like `[Parameter()]`.
 
 Always use the `CmdletBinding` attribute. All functions and scripts should begin like this:
 
@@ -123,7 +168,9 @@ Use the following template for new scripts:
 A short, one line summary of what the script does.
  
 .DESCRIPTION
-The `MY SCRIPT NAME.ps1` script... A detailed description of what the script does, why it does it, and how it does it. Your future self will forget how your script was implemented and what it does. Use the description to explain that. Your future self will thank you.
+The `MY SCRIPT NAME.ps1` script... A detailed description of what the script does, why it does it, and how it does it.
+Your future self will forget how your script was implemented and what it does. Use the description to explain that. Your
+future self will thank you.
  
 .EXAMPLE
 MY SCRIPT NAME.ps1
@@ -176,7 +223,8 @@ Get-ChildItem -Recurse |
     Select-Object -ExpandProperty 'FullName'
 ```
 
-When assigning the result of a pipeline to a variable, and the pipeline is longer than 100 characters, break each command onto its own line, and put the first command of the pipeline on the line, indented one level:
+When assigning the result of a pipeline to a variable, and the pipeline is longer than 100 characters, break each
+command onto its own line, and put the first command of the pipeline on the line, indented one level:
 
 ```powershell
 $largeFiles = 
@@ -195,9 +243,23 @@ $searchPaths = & {
 }
 ```
 
+When a string is longer than 120 characters, break it across multiple lines, using the `+` operator to concatenate the
+strings together. The `+` operator should not extend past 120 characters. Indent the second and later lines to the start
+of the string on the first line. Single quote the string on each line, unless it is using interpolation.
+
+```powershell
+$msg = "[$([Environment]::MachineName)] Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod " +
+       'tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ' +
+       'ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate ' +
+       'velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in ' +
+       'culpa qui officia deserunt mollit anim id est laborum.'
+```
+
+
 # Blocks
 
-All blocks (except script blocks) that require curly braces must have the opening and closing curly braces on their own lines:
+All blocks (except script blocks) that require curly braces must have the opening and closing curly braces on their own
+lines:
 
 ```powershell
 if( $true )
@@ -233,13 +295,15 @@ Never use `Write-Output` to return logging information. You should only ever ret
 
 Use `Write-Information` for progess-type logging information the user should always see.
 
-Use `Write-Verbose` for messages the user should see if they're trying to track down a problem or understand more about what your code is doing.
+Use `Write-Verbose` for messages the user should see if they're trying to track down a problem or understand more about
+what your code is doing.
 
 Use `Write-Debug` for messages developer-only messages.
 
 # Functions
 
-Never dot-source a script containing functions. Instead, package your functions into a module (see "Modules" section below).
+Never dot-source a script containing functions. Instead, package your functions into a module (see "Modules" section
+below).
 
 All the standards for writing scripts also apply. Additionally:
 
@@ -249,7 +313,8 @@ Never use the `filter` keyword. Instead, use `begin`/`process`/`end` blocks.
 
 When writing a function that accepts pipeline input, put the `Set-StrictMode` declaration in the begin block.
 
-If your function returns any strongly-typed objects, include an `OutputType` attribute underneath the `CmdletBinding` attribute. The `OutputType` attribute enables Intellisense in various code editors.
+If your function returns any strongly-typed objects, include an `OutputType` attribute underneath the `CmdletBinding`
+attribute. The `OutputType` attribute enables Intellisense in various code editors.
 
 ## Function Template
 
@@ -263,7 +328,8 @@ function ApprovedVerb-Noun
     A short, one line summary of what the function does.
      
     .DESCRIPTION
-    A detailed description of what the function does, why it does it, and how it does it. People want to read this rather than your code.
+    A detailed description of what the function does, why it does it, and how it does it. People want to read this
+    rather than your code.
      
     .EXAMPLE
     Demonstrates how to use this function.
@@ -289,7 +355,8 @@ function ApprovedVerb-Noun
     A short, one line summary of what the function does.
      
     .DESCRIPTION
-    A detailed description of what the function does, why it does it, and how it does it. People want to read this rather than your code.
+    A detailed description of what the function does, why it does it, and how it does it. People want to read this
+    rather than your code.
      
     .EXAMPLE
     Demonstrates how to use this function.
@@ -298,7 +365,8 @@ function ApprovedVerb-Noun
     [OutputType([Object])]
     param(
         [Parameter(Mandatory,ValueFromPipeline)]
-        # Documentation describing this parameter. Try to use a more descriptive name than InputObject. Use InputObject only if the parameter takes different types/kinds of objects.
+        # Documentation describing this parameter. Try to use a more descriptive name than InputObject. Use InputObject
+        # only if the parameter takes different types/kinds of objects.
         $InputObject
     )
  
@@ -319,7 +387,8 @@ function ApprovedVerb-Noun
 ```
 
 # Modules
-Modules are PowerShell's unit of sharing. Common functions are packaged together into modules. If you want to share functions, put them in a module. Never dot-source a file containing functions.
+Modules are PowerShell's unit of sharing. Common functions are packaged together into modules. If you want to share
+functions, put them in a module. Never dot-source a file containing functions.
 
 
 Layout a module like this:
@@ -337,38 +406,71 @@ Layout a module like this:
   + Functions
     * My-ModuleFunction1.ps1
     * My-ModuleFunction2.ps1
- + Types
-    * Type1.ps1xml 
-    * Type2.ps1xml
   * Import-MyModule.ps1
   * MyModule.psd1
   * MyModule.psm1
   * script.ps1
 ```
 
-Put XML-based extended type data into a `Types` directory. Each type should have its own file with all the extended type data for that type in that file.
-
-Put XML-based format/display data into a `Formats` directory. All formats for each object should be in its own file.
-
 Put your module's assembly and other third-party assemblies, into a `bin` directory.
 
 Put your about help topics into a directory whose name matches the locale name the help is written in.
 
-Put your module's functions into a `Functions` directory. Each function should be in its own file, whose name matches the function name.
+Put your module's functions into a `Functions` directory. Each function should be in its own file, whose name matches
+the function name.
 
-Always have a .psd1. Use New-ModuleManifest to create one.
+Do ***not*** put extended type information into `ps1xml` files. A module's custom type data isn't removed when the
+module is removed. So subsequent imports of that modules results in errors that the custom type information is already
+present. Instead, use `Get-Member` and the `Update-TypeData` cmdlet to add custom type information only when it isn't
+present.
+
+```powershell
+# Allows us to be platform agnostic in our calls of 'GetAccessControl'.
+if( -not ([IO.DirectoryInfo]::New([Environment]::CurrentDirectory) | Get-Member -Name 'GetAccessControl') )
+{
+    Update-TypeData -MemberName 'GetAccessControl' -MemberType 'ScriptMethod' -TypeName 'IO.DirectoryInfo' -Value {
+        [CmdletBinding()]
+        param(
+            [Security.AccessControl.AccessControlSections]$IncludeSections =
+                [Security.AccessControl.AccessControlSections]::All
+        )
+        
+        return [IO.FileSystemAclExtensions]::GetAccessControl($this, $IncludeSections)
+    }
+}
+```
+
+Put XML-based format/display data into a `Formats` directory. All formats for each object should be in its own file.
+
+Always have a .psd1. Use `New-ModuleManifest` to create one.
 
 Always have a .psm1 file. See the template below.
 
-Always choose and use and add a unique prefix to all of your function names. This prevents naming collisions. For example, Carbon uses `C`, BuildMasterAutomation uses `BM`, BitbucketServerAutomation uses `BBServer`, ProGetAutomation uses `ProGet`.
+Always choose and use a default command prefix for all your module's commands to avoid name conflicts with other
+modules. Set the prefix with the `DefaultCommandPrefix` property in your module's manifest. For example, Carbon uses
+`C`, `BuildMasterAutomation` uses `BM`, `BitbucketServerAutomation` uses `BBServer`, `ProGetAutomation` uses `ProGet`,
+etc.
 
-Never store global state in a module variable. Module variables should only hold information that is the same regardless of who is using your module. If your module has state it needs to keep track of (like a connection to a server or something), follow the pattern used by PowerShell: create a `New-Connection`/`New-Session`/`New-Context` function that returns an object containing that state. Update all functions that need that state to take in that object as a parameter. This way, users don't need to create different PowerShell sessions to have different state.
+Never store global state in a module variable. Module variables should only hold stateless information. If your module
+has state it needs to keep track of (like a connection to a server or something), follow the pattern used by PowerShell:
+create a `New-Connection`/`New-Session`/`New-Context` function that returns an object containing that state. Update all
+functions that need that state to take in that object as a parameter. This way, users don't need to create different
+PowerShell sessions to have different state.
 
-List your exported functions, variables, aliases, etc. in your module manifest. Don't use `Export-ModuleMember` unless your module doesn't have a manifest.
+List your exported functions, variables, aliases, etc. in your module manifest. Don't use `Export-ModuleMember` unless
+your module doesn't have a manifest.
 
-When packaging a module for distribution and release, merge all your functions into your module's .psm1 file. Dot-sourcing each function takes a constant amount of time (it takes about a second to import about 30 files). We use [Whiskey](https://github.com/webmd-health-services/Whiskey/wiki) to build, test, package, and publish all our module. It has a [MergeFile](https://github.com/webmd-health-services/Whiskey/wiki/MergeFile-Task) task that will merge your functions into your .psm1 file during your build.
+When packaging a module for distribution and release, merge all your functions into your module's .psm1 file.
+Dot-sourcing each function takes a constant amount of time (it takes about a second to import about 30 files). We use
+[Whiskey](https://github.com/webmd-health-services/Whiskey/wiki) to build, test, package, and publish all our modules.
+It has a [MergeFile](https://github.com/webmd-health-services/Whiskey/wiki/MergeFile-Task) task that will merge your
+functions into your .psm1 file during your build.
 
-Module functions don't inherit the preference settings from their caller's scope. This means your `Write-Verbose` and other messages won't be seen unless the caller adds `-Verbose` when calling your function or runs that preference on globally. All modules must include the [Use-CallerPreference](Use-CallerPreference.ps1) (as a private function) and every function must call `Use-CallerPreference` to use the caller's preference settings. Use the function templates above, but add `Use-CallerPreference` after `Set-StrictMode`:
+Module functions don't inherit the preference settings from their caller's scope. This means your `Write-Verbose` and
+other messages won't be seen unless the caller adds `-Verbose` when calling your function or runs that preference on
+globally. All modules must include the [Use-CallerPreference](Use-CallerPreference.ps1) (as a private function) and
+every function must call `Use-CallerPreference` to use the caller's preference settings. Use the function templates
+above, but add `Use-CallerPreference` after `Set-StrictMode`:
 
 ```powershell
     Set-StrictMode -Version 'Latest'


### PR DESCRIPTION
* Updated function/script parameter standard:
  * Comments should now go before the `[Parameter()]` attribute instead of after.
  * There should be a space between the parameter's type and name.
* Formatting (all lines include breaks at 120 characters).
* Added section on strings: when to use single quotes, how to embed interpolated expressions, when its OK to not quote
  some strings.
* Added paragraph on how to break strings longer than 120 characters across multiple lines